### PR TITLE
Add automation projects admin management

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -23,6 +23,7 @@ $allowed_pages = [
     'manage_bookings'=> 'manage_bookings.php',
     'manage_users'   => 'manage_users.php',
     'manage_webdev'  => 'manage_webdev.php',
+    'manage_automation' => 'manage_automation.php',
 ];
 
 // Determine requested page or default to dashboard
@@ -89,6 +90,14 @@ require_once('admin_includes/admin_heading.php');
                     </a>
                 </li>
                 <li>
+                    <a href="?page=manage_automation" class="<?php echo $page === 'manage_automation' ? 'active' : '';  ?>">
+                        <span class="nav-icon">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="4" width="16" height="16" rx="2" ry="2"></rect><rect x="9" y="9" width="6" height="6"></rect><line x1="9" y1="1" x2="9" y2="4"></line><line x1="15" y1="1" x2="15" y2="4"></line><line x1="9" y1="20" x2="9" y2="23"></line><line x1="15" y1="20" x2="15" y2="23"></line><line x1="20" y1="9" x2="23" y2="9"></line><line x1="20" y1="15" x2="23" y2="15"></line><line x1="1" y1="9" x2="4" y2="9"></line><line x1="1" y1="15" x2="4" y2="15"></line></svg>
+                        </span>
+                        <span>Automation Projects</span>
+                    </a>
+                </li>
+                <li>
                     <a href="?page=manage_bookings" class="<?php echo $page === 'manage_bookings' ? 'active' : ''; ?>">
                         <span class="nav-icon">
                             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect><line x1="16" y1="2" x2="16" y2="6"></line><line x1="8" y1="2" x2="8" y2="6"></line><line x1="3" y1="10" x2="21" y2="10"></line></svg>
@@ -137,6 +146,9 @@ require_once('admin_includes/admin_heading.php');
                             break;
                         case 'manage_webdev':
                             echo 'Manage Web Projects';
+                            break;
+                        case 'manage_automation':
+                            echo 'Manage Automation Projects';
                             break;
                         case 'manage_bookings':
                             echo 'Manage Bookings';

--- a/admin/admin_styles/manage_automation.css
+++ b/admin/admin_styles/manage_automation.css
@@ -1,0 +1,425 @@
+/**
+ * Automation Projects Manager Styles
+ * Consistent with admin panel design
+ */
+
+/* Automation dashboard layout */
+.automation-dashboard {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--spacing-lg);
+    margin-bottom: var(--spacing-xl);
+}
+
+@media (max-width: 1200px) {
+    .automation-dashboard {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* Project form container */
+.project-form-container {
+    background-color: var(--primary-bg);
+    padding: var(--spacing-lg);
+    border-radius: var(--border-radius);
+    border: 1px solid var(--border-color);
+}
+
+.project-form-container h2 {
+    font-size: 1.2rem;
+    color: var(--text-primary);
+    margin-bottom: var(--spacing-lg);
+    font-weight: 500;
+    padding-bottom: var(--spacing-sm);
+    border-bottom: 1px solid var(--border-color);
+}
+
+/* Projects list container */
+.projects-list-container {
+    background-color: var(--primary-bg);
+    padding: var(--spacing-lg);
+    border-radius: var(--border-radius);
+    border: 1px solid var(--border-color);
+}
+
+.projects-list-container h2 {
+    font-size: 1.2rem;
+    color: var(--text-primary);
+    margin-bottom: var(--spacing-lg);
+    font-weight: 500;
+    padding-bottom: var(--spacing-sm);
+    border-bottom: 1px solid var(--border-color);
+}
+
+/* Form elements */
+.form-group {
+    margin-bottom: var(--spacing-lg);
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: var(--spacing-sm);
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+}
+
+.form-group input,
+.form-group select,
+.form-group textarea {
+    width: 100%;
+    padding: var(--spacing-md);
+    background-color: rgba(255, 255, 255, 0.05);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    color: var(--text-primary);
+    transition: all var(--transition-speed) ease;
+}
+
+.form-group select {
+    appearance: none;
+    background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23AAAAAA' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right 0.8rem center;
+    background-size: 1.2rem;
+}
+
+.form-group input:focus,
+.form-group select:focus,
+.form-group textarea:focus {
+    outline: none;
+    border-color: var(--accent-color);
+    background-color: rgba(255, 255, 255, 0.08);
+}
+
+.form-group small {
+    display: block;
+    margin-top: var(--spacing-xs);
+    color: var(--text-muted);
+    font-size: 0.8rem;
+}
+
+/* Image Preview */
+.image-preview-container {
+    width: 100%;
+    min-height: 150px;
+    margin-bottom: var(--spacing-sm);
+    background-color: rgba(255, 255, 255, 0.02);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    position: relative;
+}
+
+.image-preview {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.image-preview.has-image {
+    background-color: transparent;
+}
+
+.image-preview img {
+    max-width: 100%;
+    max-height: 200px;
+    object-fit: contain;
+}
+
+#projectImage {
+    position: absolute;
+    opacity: 0;
+    width: 100%;
+    height: 100%;
+    cursor: pointer;
+    z-index: 2;
+}
+
+.upload-label {
+    padding: var(--spacing-sm) var(--spacing-md);
+    background-color: rgba(255, 255, 255, 0.1);
+    border-radius: var(--border-radius);
+    color: var(--text-primary);
+    font-size: 0.9rem;
+    cursor: pointer;
+    z-index: 1;
+}
+
+/* Form actions */
+.form-actions {
+    display: flex;
+    justify-content: flex-start;
+    gap: var(--spacing-md);
+    margin-top: var(--spacing-xl);
+}
+
+/* Buttons */
+.btn {
+    padding: var(--spacing-md) var(--spacing-lg);
+    border-radius: var(--border-radius);
+    cursor: pointer;
+    transition: all var(--transition-speed) ease;
+    font-size: 0.95rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.btn-primary {
+    background-color: var(--accent-color);
+    color: white;
+    border: none;
+}
+
+.btn-primary:hover {
+    background-color: var(--accent-hover);
+}
+
+.btn-secondary {
+    background-color: transparent;
+    border: 1px solid var(--border-color);
+    color: var(--text-secondary);
+}
+
+.btn-secondary:hover {
+    color: var(--text-primary);
+    border-color: var(--text-primary);
+}
+
+/* Filters */
+.filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-md);
+    margin-bottom: var(--spacing-lg);
+    padding-bottom: var(--spacing-lg);
+    border-bottom: 1px solid var(--border-color);
+}
+
+.filter-group {
+    flex: 1;
+    min-width: 200px;
+}
+
+.filter-group label {
+    display: block;
+    margin-bottom: var(--spacing-sm);
+    color: var(--text-secondary);
+    font-size: 0.9rem;
+}
+
+.filter-group input,
+.filter-group select {
+    width: 100%;
+    padding: var(--spacing-sm) var(--spacing-md);
+    background-color: rgba(255, 255, 255, 0.05);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    color: var(--text-primary);
+}
+
+/* Projects table */
+.table-responsive {
+    overflow-x: auto;
+    margin-top: var(--spacing-md);
+}
+
+.projects-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.projects-table th,
+.projects-table td {
+    padding: var(--spacing-md);
+    text-align: left;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.projects-table th {
+    background-color: rgba(255, 255, 255, 0.05);
+    color: var(--text-primary);
+    font-weight: 500;
+}
+
+.projects-table td {
+    color: var(--text-secondary);
+}
+
+.projects-table tbody tr:hover {
+    background-color: rgba(255, 255, 255, 0.02);
+}
+
+/* Project thumbnail */
+.project-thumbnail {
+    width: 80px;
+    height: 60px;
+    overflow: hidden;
+    border-radius: var(--border-radius);
+    background-color: rgba(0, 0, 0, 0.2);
+}
+
+.project-thumbnail img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+/* Button styles */
+.action-buttons {
+    display: flex;
+    gap: var(--spacing-sm);
+}
+
+.btn-edit {
+    background-color: rgba(70, 130, 180, 0.2);
+    color: var(--text-secondary);
+    border: none;
+    padding: var(--spacing-sm) var(--spacing-md);
+    border-radius: var(--border-radius);
+    cursor: pointer;
+}
+
+.btn-edit:hover {
+    background-color: rgba(70, 130, 180, 0.4);
+    color: var(--text-primary);
+}
+
+.btn-delete {
+    background-color: rgba(244, 67, 54, 0.2);
+    color: var(--text-secondary);
+    border: none;
+    padding: var(--spacing-sm) var(--spacing-md);
+    border-radius: var(--border-radius);
+    cursor: pointer;
+}
+
+.btn-delete:hover {
+    background-color: rgba(244, 67, 54, 0.4);
+    color: var(--text-primary);
+}
+
+/* Delete Modal */
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(15, 16, 19, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    opacity: 0;
+    visibility: hidden;
+    transition: all var(--transition-speed) ease;
+}
+
+.modal.active {
+    opacity: 1;
+    visibility: visible;
+}
+
+.modal-content {
+    background-color: var(--secondary-bg);
+    border-radius: var(--border-radius);
+    width: 90%;
+    max-width: 500px;
+    border: 1px solid var(--border-color);
+    overflow: hidden;
+}
+
+.modal-content h3 {
+    font-size: 1.2rem;
+    color: var(--text-primary);
+    margin-bottom: var(--spacing-md);
+    font-weight: 500;
+    padding: var(--spacing-lg);
+    border-bottom: 1px solid var(--border-color);
+}
+
+.modal-content p {
+    padding: 0 var(--spacing-lg);
+    margin-bottom: var(--spacing-lg);
+    color: var(--text-secondary);
+    line-height: 1.5;
+}
+
+.modal-actions {
+    padding: var(--spacing-md) var(--spacing-lg);
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--spacing-md);
+    border-top: 1px solid var(--border-color);
+}
+
+/* Status messages */
+.status-message {
+    margin-bottom: var(--spacing-lg);
+    padding: var(--spacing-md) var(--spacing-lg);
+    border-radius: var(--border-radius);
+    position: relative;
+    transition: opacity var(--transition-speed) ease;
+    border-left: 4px solid;
+}
+
+.status-message.success {
+    background-color: rgba(76, 175, 80, 0.1);
+    border-left-color: #4CAF50;
+    color: #A5D6A7;
+}
+
+.status-message.error {
+    background-color: rgba(244, 67, 54, 0.1);
+    border-left-color: #F44336;
+    color: #EF9A9A;
+}
+
+/* Loading state */
+.loading-row td {
+    text-align: center;
+    color: var(--text-secondary);
+    padding: var(--spacing-xl) !important;
+}
+
+/* Responsive design */
+@media (max-width: 992px) {
+    .filters {
+        flex-direction: column;
+    }
+    
+    .form-actions {
+        flex-direction: column;
+    }
+    
+    .btn {
+        width: 100%;
+    }
+}
+
+@media (max-width: 768px) {
+    .projects-table th:nth-child(4),
+    .projects-table td:nth-child(4),
+    .projects-table th:nth-child(5),
+    .projects-table td:nth-child(5) {
+        display: none;
+    }
+    
+    .project-thumbnail {
+        width: 60px;
+        height: 45px;
+    }
+}
+
+@media (max-width: 576px) {
+    .projects-table th:nth-child(1),
+    .projects-table td:nth-child(1) {
+        display: none;
+    }
+}

--- a/admin/manage_automation.php
+++ b/admin/manage_automation.php
@@ -1,0 +1,575 @@
+<?php
+require_once('../config.php');
+
+// Check if the user is logged in and has the 'admin' role
+if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true || $_SESSION['role'] !== 'admin') {
+    // Optionally, set a flash message about unauthorized access
+    header('Location: ../index.php');
+    exit;
+}
+
+// Create automation_projects table if it doesn't exist
+$createTableQuery = "
+CREATE TABLE IF NOT EXISTS `automation_projects` (
+  `project_id` int(11) NOT NULL AUTO_INCREMENT,
+  `title` varchar(255) NOT NULL,
+  `category` varchar(50) NOT NULL,
+  `short_description` varchar(255) NOT NULL,
+  `description` text NOT NULL,
+  `client` varchar(100) NOT NULL,
+  `tools` varchar(255) NOT NULL,
+  `image_url` varchar(255) NOT NULL,
+  `workflow_url` varchar(255) DEFAULT NULL,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` timestamp NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (`project_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+";
+
+if ($conn->query($createTableQuery) !== TRUE) {
+    error_log("Error creating automation_projects table: " . $conn->error);
+}
+
+// Create the directory for project images if it doesn't exist
+$uploadDir = $_SERVER['DOCUMENT_ROOT'] . '/static/images/automation_projects/';
+if (!file_exists($uploadDir)) {
+    if (!mkdir($uploadDir, 0755, true)) {
+        error_log("Error creating directory: $uploadDir");
+    }
+}
+
+// Handle form submissions for adding, updating, or deleting projects
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    // Process the form data
+    if (isset($_POST['action'])) {
+        $action = $_POST['action'];
+        
+        switch ($action) {
+            case 'create':
+                handleCreateProject($conn, $uploadDir);
+                break;
+            case 'update':
+                handleUpdateProject($conn, $uploadDir);
+                break;
+            case 'delete':
+                handleDeleteProject($conn);
+                break;
+        }
+    }
+}
+
+// Get project for editing if ID is provided
+$projectToEdit = null;
+if (isset($_GET['edit']) && !empty($_GET['edit'])) {
+    $projectId = (int)$_GET['edit'];
+    $stmt = $conn->prepare("
+        SELECT * FROM automation_projects WHERE project_id = ?
+    ");
+    $stmt->bind_param("i", $projectId);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    
+    if ($result && $result->num_rows > 0) {
+        $projectToEdit = $result->fetch_assoc();
+    }
+    $stmt->close();
+}
+
+// Fetch all projects for the table
+$category = isset($_GET['category']) ? trim($_GET['category']) : '';
+$search = isset($_GET['search']) ? trim($_GET['search']) : '';
+
+$query = "SELECT * FROM automation_projects WHERE 1=1";
+$params = [];
+$types = '';
+
+if (!empty($category)) {
+    $query .= " AND category = ?";
+    $params[] = $category;
+    $types .= 's';
+}
+
+if (!empty($search)) {
+    $query .= " AND (
+        title LIKE ? OR 
+        short_description LIKE ? OR
+        description LIKE ? OR
+        client LIKE ? OR
+        tools LIKE ?
+    )";
+    
+    $searchPattern = "%$search%";
+    $params[] = $searchPattern;
+    $params[] = $searchPattern;
+    $params[] = $searchPattern;
+    $params[] = $searchPattern;
+    $params[] = $searchPattern;
+    
+    $types .= 'sssss';
+}
+
+$query .= " ORDER BY created_at DESC";
+
+$stmt = $conn->prepare($query);
+
+if (!empty($params)) {
+    $bindParams = array_merge([$types], $params);
+    $stmt->bind_param(...$bindParams);
+}
+
+$stmt->execute();
+$projects = $stmt->get_result();
+$stmt->close();
+
+/**
+ * Handle creating a new project
+ */
+function handleCreateProject($conn, $uploadDir) {
+    // Validate required fields
+    $requiredFields = ['title', 'category', 'client', 'short_description', 'description', 'tools'];
+    foreach ($requiredFields as $field) {
+        if (!isset($_POST[$field]) || trim($_POST[$field]) === '') {
+            setStatusMessage('error', "Missing required field: $field");
+            return;
+        }
+    }
+    
+    // Handle image upload
+    $imagePath = '';
+    if (isset($_FILES['image']) && $_FILES['image']['error'] == 0) {
+        $imagePath = handleImageUpload($_FILES['image'], $uploadDir);
+        if (!$imagePath) {
+            // Error message is set by handleImageUpload
+            return;
+        }
+    } else {
+        setStatusMessage('error', 'Project image is required');
+        return;
+    }
+    
+    // Prepare data for insertion
+    $title = trim($_POST['title']);
+    $category = trim($_POST['category']);
+    $client = trim($_POST['client']);
+    $shortDescription = trim($_POST['short_description']);
+    $description = trim($_POST['description']);
+    $tools = trim($_POST['tools']);
+    $workflowUrl = isset($_POST['workflow_url']) ? trim($_POST['workflow_url']) : null;
+    
+    // Insert the project
+    $stmt = $conn->prepare("
+        INSERT INTO automation_projects (title, category, short_description, description, client, tools, image_url, workflow_url)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    ");
+    
+    if (!$stmt) {
+        setStatusMessage('error', 'Database error: ' . $conn->error);
+        return;
+    }
+    
+    $stmt->bind_param("ssssssss", $title, $category, $shortDescription, $description, $client, $tools, $imagePath, $workflowUrl);
+    
+    if (!$stmt->execute()) {
+        setStatusMessage('error', 'Failed to create project: ' . $stmt->error);
+        return;
+    }
+    
+    $stmt->close();
+    setStatusMessage('success', 'Project created successfully');
+    
+    // Redirect to clear form
+    header('Location: admin.php?page=manage_automation');
+    exit;
+}
+
+/**
+ * Handle updating an existing project
+ */
+function handleUpdateProject($conn, $uploadDir) {
+    // Check project ID
+    if (!isset($_POST['project_id']) || empty($_POST['project_id'])) {
+        setStatusMessage('error', 'Project ID is required');
+        return;
+    }
+    
+    $projectId = (int)$_POST['project_id'];
+    
+    // Validate required fields
+    $requiredFields = ['title', 'category', 'client', 'short_description', 'description', 'tools'];
+    foreach ($requiredFields as $field) {
+        if (!isset($_POST[$field]) || trim($_POST[$field]) === '') {
+            setStatusMessage('error', "Missing required field: $field");
+            return;
+        }
+    }
+    
+    // Handle image upload if a new image is provided
+    $imagePath = isset($_POST['current_image']) ? $_POST['current_image'] : '';
+    if (isset($_FILES['image']) && $_FILES['image']['error'] == 0) {
+        $newImagePath = handleImageUpload($_FILES['image'], $uploadDir);
+        if ($newImagePath) {
+            // If successful upload, replace the old path
+            $imagePath = $newImagePath;
+            
+            // Delete old image if it exists and is different
+            if (isset($_POST['current_image']) && $_POST['current_image'] && $newImagePath !== $_POST['current_image']) {
+                $oldImagePath = $_SERVER['DOCUMENT_ROOT'] . '/' . $_POST['current_image'];
+                if (file_exists($oldImagePath)) {
+                    unlink($oldImagePath);
+                }
+            }
+        } else {
+            // Error message is set by handleImageUpload
+            return;
+        }
+    }
+    
+    // Prepare data for update
+    $title = trim($_POST['title']);
+    $category = trim($_POST['category']);
+    $client = trim($_POST['client']);
+    $shortDescription = trim($_POST['short_description']);
+    $description = trim($_POST['description']);
+    $tools = trim($_POST['tools']);
+    $workflowUrl = isset($_POST['workflow_url']) ? trim($_POST['workflow_url']) : null;
+    
+    // Update the project
+    $stmt = $conn->prepare("
+        UPDATE automation_projects
+        SET title = ?, category = ?, short_description = ?, description = ?,
+            client = ?, tools = ?, image_url = ?, workflow_url = ?
+        WHERE project_id = ?
+    ");
+    
+    if (!$stmt) {
+        setStatusMessage('error', 'Database error: ' . $conn->error);
+        return;
+    }
+    
+    $stmt->bind_param("ssssssssi", $title, $category, $shortDescription, $description, $client, $tools, $imagePath, $workflowUrl, $projectId);
+    
+    if (!$stmt->execute()) {
+        setStatusMessage('error', 'Failed to update project: ' . $stmt->error);
+        return;
+    }
+    
+    $stmt->close();
+    setStatusMessage('success', 'Project updated successfully');
+    
+    // Redirect to clear form
+    header('Location: admin.php?page=manage_automation');
+    exit;
+}
+
+/**
+ * Handle deleting a project
+ */
+function handleDeleteProject($conn) {
+    // Check project ID
+    if (!isset($_POST['project_id']) || empty($_POST['project_id'])) {
+        setStatusMessage('error', 'Project ID is required');
+        return;
+    }
+    
+    $projectId = (int)$_POST['project_id'];
+    
+    // Get the image path first to delete the file later
+    $stmt = $conn->prepare("SELECT image_url FROM automation_projects WHERE project_id = ?");
+    $stmt->bind_param("i", $projectId);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    
+    if ($result->num_rows > 0) {
+        $project = $result->fetch_assoc();
+        $imagePath = $project['image_url'];
+    }
+    
+    $stmt->close();
+    
+    // Delete the project from the database
+    $stmt = $conn->prepare("DELETE FROM automation_projects WHERE project_id = ?");
+    $stmt->bind_param("i", $projectId);
+    
+    if (!$stmt->execute()) {
+        setStatusMessage('error', 'Failed to delete project: ' . $stmt->error);
+        return;
+    }
+    
+    $stmt->close();
+    
+    // Delete the image file if it exists
+    if (isset($imagePath) && $imagePath) {
+        $fullImagePath = $_SERVER['DOCUMENT_ROOT'] . '/' . $imagePath;
+        if (file_exists($fullImagePath)) {
+            unlink($fullImagePath);
+        }
+    }
+    
+    setStatusMessage('success', 'Project deleted successfully');
+    
+    // Redirect to update the list
+    header('Location: admin.php?page=manage_automation');
+    exit;
+}
+
+/**
+ * Handle image upload and return the path
+ */
+function handleImageUpload($file, $uploadDir) {
+    // Validate file
+    $allowedTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+    $maxSize = 5 * 1024 * 1024; // 5MB
+    
+    if (!in_array($file['type'], $allowedTypes)) {
+        setStatusMessage('error', 'Invalid file type. Allowed: JPG, PNG, GIF, WEBP');
+        return false;
+    }
+    
+    if ($file['size'] > $maxSize) {
+        setStatusMessage('error', 'File too large. Maximum: 5MB');
+        return false;
+    }
+    
+    // Generate unique filename
+    $fileExtension = pathinfo($file['name'], PATHINFO_EXTENSION);
+    $fileName = 'project_' . time() . '_' . mt_rand(1000, 9999) . '.' . $fileExtension;
+    $targetFile = $uploadDir . $fileName;
+    
+    // Move uploaded file
+    if (!move_uploaded_file($file['tmp_name'], $targetFile)) {
+        setStatusMessage('error', 'Error uploading file');
+        return false;
+    }
+    
+    // Return relative path for database storage
+    return 'static/images/automation_projects/' . $fileName;
+}
+
+/**
+ * Set status message in session
+ */
+function setStatusMessage($type, $message) {
+    $_SESSION['status_type'] = $type;
+    $_SESSION['status_message'] = $message;
+}
+?>
+
+<!-- Include the CSS file -->
+<link rel="stylesheet" href="../admin/admin_styles/manage_automation.css">
+
+<h1>Manage Automation Projects</h1>
+
+<!-- Status Messages -->
+<?php if (isset($_SESSION['status_message'])): ?>
+    <div class="status-message <?php echo $_SESSION['status_type']; ?>">
+        <?php 
+            echo htmlspecialchars($_SESSION['status_message']); 
+            // Clear the messages
+            unset($_SESSION['status_type']);
+            unset($_SESSION['status_message']);
+        ?>
+    </div>
+<?php endif; ?>
+
+<div class="automation-dashboard">
+    <!-- Project Form Section -->
+    <div class="project-form-container">
+        <h2><?php echo $projectToEdit ? 'Edit Project' : 'Add New Project'; ?></h2>
+        <form id="projectForm" method="POST" enctype="multipart/form-data">
+            <input type="hidden" name="action" value="<?php echo $projectToEdit ? 'update' : 'create'; ?>">
+            <?php if ($projectToEdit): ?>
+                <input type="hidden" name="project_id" value="<?php echo $projectToEdit['project_id']; ?>">
+                <input type="hidden" name="current_image" value="<?php echo $projectToEdit['image_url']; ?>">
+            <?php endif; ?>
+            
+            <!-- Title -->
+            <div class="form-group">
+                <label for="title">Project Title:</label>
+                <input type="text" id="title" name="title" required value="<?php echo $projectToEdit ? htmlspecialchars($projectToEdit['title']) : ''; ?>">
+            </div>
+            
+            <!-- Category -->
+            <div class="form-group">
+                <label for="category">Category:</label>
+                <select id="category" name="category" required>
+                    <option value="">Select a category</option>
+                    <?php
+                    $categories = ['Marketing Automation', 'Sales Automation', 'Operations Automation', 'Data Processing', 'Other'];
+                    foreach ($categories as $cat) {
+                        $selected = ($projectToEdit && $projectToEdit['category'] === $cat) ? 'selected' : '';
+                        echo "<option value=\"$cat\" $selected>$cat</option>";
+                    }
+                    ?>
+                </select>
+            </div>
+            
+            <!-- Client -->
+            <div class="form-group">
+                <label for="client">Client:</label>
+                <input type="text" id="client" name="client" required value="<?php echo $projectToEdit ? htmlspecialchars($projectToEdit['client']) : ''; ?>">
+            </div>
+            
+            <!-- Short Description -->
+            <div class="form-group">
+                <label for="shortDescription">Short Description:</label>
+                <textarea id="shortDescription" name="short_description" rows="2" maxlength="255" required><?php echo $projectToEdit ? htmlspecialchars($projectToEdit['short_description']) : ''; ?></textarea>
+                <small>Brief overview for project listing (max 255 characters)</small>
+            </div>
+            
+            <!-- Full Description -->
+            <div class="form-group">
+                <label for="description">Full Description:</label>
+                <textarea id="description" name="description" rows="6" required><?php echo $projectToEdit ? htmlspecialchars($projectToEdit['description']) : ''; ?></textarea>
+            </div>
+            
+            <!-- Tools/Platforms Used -->
+            <div class="form-group">
+                <label for="tools">Tools/Platforms Used:</label>
+                <input type="text" id="tools" name="tools" required value="<?php echo $projectToEdit ? htmlspecialchars($projectToEdit['tools']) : ''; ?>">
+                <small>Separate with commas (e.g., n8n, Zapier, Make)</small>
+            </div>
+            
+            <!-- Workflow URL -->
+            <div class="form-group">
+                <label for="workflowUrl">Workflow URL (optional):</label>
+                <input type="url" id="workflowUrl" name="workflow_url" placeholder="https://" value="<?php echo $projectToEdit ? htmlspecialchars($projectToEdit['workflow_url']) : ''; ?>">
+            </div>
+            
+            <!-- Image Upload -->
+            <div class="form-group">
+                <label for="projectImage">Project Image:</label>
+                <div id="imagePreviewContainer" class="image-preview-container">
+                    <div id="imagePreview" class="image-preview <?php echo $projectToEdit ? 'has-image' : ''; ?>">
+                        <?php if ($projectToEdit && $projectToEdit['image_url']): ?>
+                            <img src="/<?php echo htmlspecialchars($projectToEdit['image_url']); ?>" alt="<?php echo htmlspecialchars($projectToEdit['title']); ?>">
+                        <?php endif; ?>
+                    </div>
+                    <input type="file" id="projectImage" name="image" accept="image/*" <?php echo $projectToEdit ? '' : 'required'; ?>>
+                    <label for="projectImage" class="upload-label">Choose File</label>
+                </div>
+                <small>Recommended size: 1200x800px, Max size: 5MB<?php echo $projectToEdit ? ' (upload a new image only if you want to replace the current one)' : ''; ?></small>
+            </div>
+            
+            <!-- Form Buttons -->
+            <div class="form-actions">
+                <button type="submit" class="btn btn-primary"><?php echo $projectToEdit ? 'Update Project' : 'Save Project'; ?></button>
+                <?php if ($projectToEdit): ?>
+                    <a href="admin.php?page=manage_automation" class="btn btn-secondary">Cancel</a>
+                <?php endif; ?>
+            </div>
+        </form>
+    </div>
+
+    <!-- Projects List Section -->
+    <div class="projects-list-container">
+        <h2>Existing Projects</h2>
+        
+        <!-- Filters -->
+        <form method="GET" class="filters">
+            <input type="hidden" name="page" value="manage_automation">
+            <div class="filter-group">
+                <label for="categoryFilter">Filter by Category:</label>
+                <select id="categoryFilter" name="category" onchange="this.form.submit()">
+                    <option value="">All Categories</option>
+                    <?php
+                    foreach ($categories as $cat) {
+                        $selected = ($category === $cat) ? 'selected' : '';
+                        echo "<option value=\"$cat\" $selected>$cat</option>";
+                    }
+                    ?>
+                </select>
+            </div>
+            
+            <div class="filter-group">
+                <label for="searchFilter">Search:</label>
+                <input type="text" id="searchFilter" name="search" value="<?php echo htmlspecialchars($search); ?>" placeholder="Search projects...">
+                <button type="submit" class="btn">Search</button>
+                <?php if (!empty($category) || !empty($search)): ?>
+                    <a href="admin.php?page=manage_automation" class="btn btn-secondary">Clear Filters</a>
+                <?php endif; ?>
+            </div>
+        </form>
+        
+        <!-- Projects Table -->
+        <div class="table-responsive">
+            <table class="projects-table">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Image</th>
+                        <th>Title</th>
+                        <th>Category</th>
+                        <th>Description</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php if ($projects && $projects->num_rows > 0): ?>
+                        <?php while ($project = $projects->fetch_assoc()): ?>
+                            <tr>
+                                <td><?php echo $project['project_id']; ?></td>
+                                <td>
+                                    <div class="project-thumbnail">
+                                        <img src="/<?php echo htmlspecialchars($project['image_url']); ?>" 
+                                             alt="<?php echo htmlspecialchars($project['title']); ?>"
+                                             onerror="this.src='data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%22100%22 height=%22100%22 viewBox=%220 0 100 100%22%3E%3Crect fill=%22%23cccccc%22 width=%22100%22 height=%22100%22/%3E%3C/svg%3E'; this.onerror=null;">
+                                    </div>
+                                </td>
+                                <td><?php echo htmlspecialchars($project['title']); ?></td>
+                                <td><?php echo htmlspecialchars($project['category']); ?></td>
+                                <td><?php echo htmlspecialchars(substr($project['short_description'], 0, 100)) . (strlen($project['short_description']) > 100 ? '...' : ''); ?></td>
+                                <td>
+                                    <div class="action-buttons">
+                                        <a href="admin.php?page=manage_automation&edit=<?php echo $project['project_id']; ?>" class="btn btn-edit">Edit</a>
+                                        <form method="POST" onsubmit="return confirm('Are you sure you want to delete this project?');" style="display: inline;">
+                                            <input type="hidden" name="action" value="delete">
+                                            <input type="hidden" name="project_id" value="<?php echo $project['project_id']; ?>">
+                                            <button type="submit" class="btn btn-delete">Delete</button>
+                                        </form>
+                                    </div>
+                                </td>
+                            </tr>
+                        <?php endwhile; ?>
+                    <?php else: ?>
+                        <tr>
+                            <td colspan="6" style="text-align: center;">No projects found</td>
+                        </tr>
+                    <?php endif; ?>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<script>
+// Simple JavaScript for image preview
+document.addEventListener('DOMContentLoaded', function() {
+    const projectImageInput = document.getElementById('projectImage');
+    const imagePreview = document.getElementById('imagePreview');
+    
+    if (projectImageInput && imagePreview) {
+        projectImageInput.addEventListener('change', function(e) {
+            const file = e.target.files[0];
+            if (!file) return;
+            
+            const reader = new FileReader();
+            reader.onload = function(event) {
+                imagePreview.innerHTML = `<img src="${event.target.result}" alt="Preview">`;
+                imagePreview.classList.add('has-image');
+            };
+            reader.readAsDataURL(file);
+        });
+    }
+    
+    // Auto-hide status message after 5 seconds
+    const statusMessage = document.querySelector('.status-message');
+    if (statusMessage) {
+        setTimeout(() => {
+            statusMessage.style.opacity = '0';
+            setTimeout(() => {
+                statusMessage.style.display = 'none';
+            }, 500);
+        }, 5000);
+    }
+});
+</script>

--- a/includes/get_automation_project_details.php
+++ b/includes/get_automation_project_details.php
@@ -1,0 +1,49 @@
+<?php
+require_once(dirname(__DIR__) . '/config.php');
+
+// Check if project ID is provided
+if(isset($_GET['id']) && is_numeric($_GET['id'])) {
+    $project_id = intval($_GET['id']);
+    
+    // Prepare SQL query to get project details
+    $sql = "SELECT * FROM automation_projects WHERE project_id = ?";
+    $stmt = $conn->prepare($sql);
+    $stmt->bind_param("i", $project_id);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    
+    if($result->num_rows > 0) {
+        // Fetch project data
+        $project = $result->fetch_assoc();
+        
+        // Format data for response
+        $response = [
+            'success' => true,
+            'project' => $project
+        ];
+        
+        // Output as JSON
+        header('Content-Type: application/json');
+        echo json_encode($response);
+    } else {
+        // Project not found
+        $response = [
+            'success' => false,
+            'message' => 'Project not found'
+        ];
+        
+        // Output as JSON
+        header('Content-Type: application/json');
+        echo json_encode($response);
+    }
+} else {
+    // Invalid or missing project ID
+    $response = [
+        'success' => false,
+        'message' => 'Invalid project ID'
+    ];
+    
+    // Output as JSON
+    header('Content-Type: application/json');
+    echo json_encode($response);
+}


### PR DESCRIPTION
## Summary
- add `manage_automation.php` to handle automation project CRUD with image uploads and workflow links
- style automation manager with `manage_automation.css`
- wire new automation page into admin navigation and page router

## Testing
- `php -l admin/manage_automation.php`
- `php -l admin/admin.php`
- `php -l includes/get_automation_project_details.php`
- `npm test` *(fails: Missing script: "test")*
- `composer test` *(fails: Command "test" is not defined.)*


------
https://chatgpt.com/codex/tasks/task_e_6897385732c88320863f52394d0359d0